### PR TITLE
Fix matrix profile

### DIFF
--- a/openrouteservice/distance_matrix.py
+++ b/openrouteservice/distance_matrix.py
@@ -81,10 +81,10 @@ def distance_matrix(client, locations,
         "sources": sources,
         "destinations": destinations
     }
+    
+    get_params = {}
 
     if profile:
-        # NOTE(broady): the mode parameter is not validated by the Maps API
-        # server. Check here to prevent silent failures.
         if profile not in ["driving-car",
                            "driving-hgv",
                            "foot-walking",
@@ -98,6 +98,7 @@ def distance_matrix(client, locations,
                            ]:
             raise ValueError("Invalid travel mode.")
         params["profile"] = profile
+        get_params['profile'] = profile
 
     if sources:
         if sources == 'all': 
@@ -126,4 +127,4 @@ def distance_matrix(client, locations,
         params["optimized"] = optimized
 
 
-    return client.request("/matrix", {}, post_json=params, dry_run=dry_run) # No get() params
+    return client.request("/matrix", get_params, post_json=params, dry_run=dry_run) 

--- a/openrouteservice/isochrones.py
+++ b/openrouteservice/isochrones.py
@@ -67,7 +67,8 @@ def isochrones(client, locations,
 
     :param attributes: 'area' returns the area of each polygon in its feature
         properties. 'reachfactor' returns a reachability score between 0 and 1.
-        One or more of ['area', 'reachfactor']. Default 'area'.
+        'total_pop' returns population statistics from https://ghsl.jrc.ec.europa.eu/about.php.
+        One or more of ['area', 'reachfactor', 'total_pop']. Default 'area'.
     :type attributes: list of string(s)
 
     :param options: not implemented right now.


### PR DESCRIPTION
When specifying alternative profiles in matrix POST request, they must be included in the URL in GET style.