### PR TITLE
get_params is now ignored if not set

### DIFF
--- a/openrouteservice/client.py
+++ b/openrouteservice/client.py
@@ -263,6 +263,8 @@ class Client(object):
 
         if type(params) is dict:
             params = sorted(dict(**params).items())
+        elif params is None:
+            return path
 
         return path + "?" + _urlencode_params(params)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -115,6 +115,23 @@ class ClientTest(_test.TestCase):
         self.assertEqual(0, len(responses.calls))
 
     @responses.activate
+    def test_no_get_parameter(self):
+
+        responses.add(responses.POST,
+                      'https://api.openrouteservice.org/directions',
+                      body='{"status":"OK","results":[]}',
+                      status=200,
+                      content_type='application/json')
+
+        req = self.client.request(post_json={},
+                                  url='v2/directions/driving-car/json',
+                                  dry_run='true')
+
+        self.assertEqual(0, len(responses.calls))
+
+    # Test if the client works with a post request without a get parameter
+
+    @responses.activate
     def test_key_in_header(self):
         # Test that API key is being put in the Authorization header
         query = ENDPOINT_DICT['directions']


### PR DESCRIPTION
When the [last example from the readme](https://github.com/GIScience/openrouteservice-py#local-ors-instance) is tried, this error occurs.

```python3
client = ors.Client(base_url=host)
resp = client.request(
    url=f'/v2/directions/{profile}/{format}',
    post_json={
        'coordinates': coords
    })
```

Error:
```bash
  …
  File "$HOME/.local/lib/python3.8/site-packages/openrouteservice/client.py", line 163, in request
    authed_url = self._generate_auth_url(url,
  File "$HOME/.local/lib/python3.8/site-packages/openrouteservice/client.py", line 267, in _generate_auth_url
    return path + "?" + _urlencode_params(params)
  File "$HOME/.local/lib/python3.8/site-packages/openrouteservice/client.py", line 330, in _urlencode_params
    params = [(key, _normalize_for_urlencode(val)) for key, val in params]
TypeError: 'NoneType' object is not iterable
```
If the parameter `get_params={}` is added, everything works as expected. The fix in this PR skips the `urlencode` line and just returns the `path` when the params are none. A test is added as well.