### PR TITLE
fix: Add missing pip update and remove pypy3.7

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9" ]
         poetry-version: [ "latest" ]
         os: [ ubuntu-20.04, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -44,6 +44,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+      - name: Update pip
+        run: |
+          python -m pip install --upgrade pip
       - name: Run Poetry action
         uses: abatilo/actions-poetry@v2
         with:


### PR DESCRIPTION
pypy3.7 has a built-in incompatibility that cannot be resolved. Hence, let's drop support.